### PR TITLE
[PR] Hard-code menu slug in add_submenu_page()

### DIFF
--- a/enable-media-replace.php
+++ b/enable-media-replace.php
@@ -37,7 +37,7 @@ add_shortcode('file_modified', 'emr_get_modified_date');
  * To suppress it in the menu we give it an empty menu title.
  */
 function emr_menu() {
-	add_submenu_page(NULL, __("Replace media", "enable-media-replace"), '','upload_files', __FILE__, 'emr_options');
+	add_submenu_page(NULL, __("Replace media", "enable-media-replace"), '','upload_files', 'enable-media-replace/enable-media-replace', 'emr_options');
 }
 
 /**


### PR DESCRIPTION
Using `__FILE__` as the menu slug when adding the submenu page causes an issue when the plugin is installed in a directory other than `enable-media-replace/`.

By hard-coding it to match the slug used throughout the plugin, directories such as `enable-media-replace-dev` can be used.
