### PR TITLE
NOTREADY [PR] Use WordPress core APIs rather than direct SQL

### DIFF
--- a/popup.php
+++ b/popup.php
@@ -13,16 +13,11 @@
 if (!current_user_can('upload_files'))
 	wp_die(__('You do not have permission to upload files.', 'enable-media-replace'));
 
-global $wpdb;
-
-$table_name = $wpdb->prefix . "posts";
-
-$sql = "SELECT guid, post_mime_type FROM $table_name WHERE ID = " . (int) $_GET["attachment_id"];
-
-list($current_filename, $current_filetype) = $wpdb->get_row($sql, ARRAY_N);
-
+$current_file = get_post( absint( $_GET['attachment_id'] ) );
+$current_filename = $current_file->guid;
 $current_filename = substr($current_filename, (strrpos($current_filename, "/") + 1));
 
+$current_filetype = $current_file->post_mime_type;
 
 ?>
 <div class="wrap">

--- a/upload.php
+++ b/upload.php
@@ -58,10 +58,9 @@ function emr_delete_current_files($current_file) {
 
 }
 
-
-// Get old guid and filetype from DB
-$sql = "SELECT guid, post_mime_type FROM $table_name WHERE ID = '" . (int) $_POST["ID"] . "'";
-list($current_filename, $current_filetype) = $wpdb->get_row($sql, ARRAY_N);
+$current_file = get_post( absint( $_POST['ID'] ) );
+$current_filename = $current_file->guid;
+$current_filetype = $current_file->post_mime_type;
 
 // Massage a bunch of vars
 $current_guid = $current_filename;

--- a/upload.php
+++ b/upload.php
@@ -170,7 +170,7 @@ if (is_uploaded_file($_FILES["userfile"]["tmp_name"])) {
 
 	}
 
-	$returnurl = get_bloginfo("wpurl") . "/wp-admin/post.php?post={$_POST["ID"]}&action=edit&message=1";
+	$returnurl = admin_url( 'post.php?post=' . absint( $_POST['ID'] ) . '&action=edit&message=1' );
 	
 	// Execute hook actions - thanks rubious for the suggestion!
 	if (isset($new_guid)) { do_action("enable-media-replace-upload-done", ($new_guid ? $new_guid : $current_guid)); }
@@ -178,7 +178,7 @@ if (is_uploaded_file($_FILES["userfile"]["tmp_name"])) {
 } else {
 	//TODO Better error handling when no file is selected.
 	//For now just go back to media management
-	$returnurl = get_bloginfo("wpurl") . "/wp-admin/upload.php";
+	$returnurl = admin_url( '/wp-admin/upload.php' );
 }
 
 if (FORCE_SSL_ADMIN) {

--- a/upload.php
+++ b/upload.php
@@ -139,21 +139,11 @@ if (is_uploaded_file($_FILES["userfile"]["tmp_name"])) {
 		// Update the postmeta file name
 
 		// Get old postmeta _wp_attached_file
-		$sql = $wpdb->prepare(
-			"SELECT meta_value FROM $postmeta_table_name WHERE meta_key = '_wp_attached_file' AND post_id = %d;",
-			(int) $_POST["ID"]
-		);
-		
-		$old_meta_name = $wpdb->get_row($sql, ARRAY_A);
-		$old_meta_name = $old_meta_name["meta_value"];
+		$old_meta_name = get_post_meta( absint( $_POST['id'] ), '_wp_attached_file', true );
 
 		// Make new postmeta _wp_attached_file
 		$new_meta_name = str_replace($current_filename, $new_filename, $old_meta_name);
-		$sql = $wpdb->prepare(
-			"UPDATE $postmeta_table_name SET meta_value = '$new_meta_name' WHERE meta_key = '_wp_attached_file' AND post_id = %d;",
-			(int) $_POST["ID"]
-		);
-		$wpdb->query($sql);
+		update_post_meta( absint( $_POST['ID'] ), '_wp_attached_file', $new_meta_name );
 
 		// Make thumb and/or update metadata
 		wp_update_attachment_metadata( (int) $_POST["ID"], wp_generate_attachment_metadata( (int) $_POST["ID"], $new_file) );

--- a/upload.php
+++ b/upload.php
@@ -127,11 +127,14 @@ if (is_uploaded_file($_FILES["userfile"]["tmp_name"])) {
 		$new_guid = str_replace($current_filename, $new_filename, $current_guid);
 
 		// Update database file name
-		$sql = $wpdb->prepare(
-			"UPDATE $table_name SET post_title = '$new_filetitle', post_name = '$new_filetitle', guid = '$new_guid', post_mime_type = '$new_filetype' WHERE ID = %d;",
-			(int) $_POST["ID"]
-		);
-		$wpdb->query($sql);
+		wp_update_post( array(
+			'ID' => absint( $_POST['ID'] ),
+			'post_type' => 'attachment',
+			'post_title' => $new_filetitle,
+			'post_name' => $new_filetitle,
+			'guid' => $new_guid,
+			'post_mime_type' => $new_filetype,
+		));
 
 		// Update the postmeta file name
 

--- a/upload.php
+++ b/upload.php
@@ -162,12 +162,7 @@ if (is_uploaded_file($_FILES["userfile"]["tmp_name"])) {
 			$post_content = $rows["post_content"];
 			$post_content = addslashes(str_replace($current_guid, $new_guid, $post_content));
 
-			$sql = $wpdb->prepare(
-				"UPDATE $table_name SET post_content = '$post_content' WHERE ID = %d;",
-				$rows["ID"]
-			);
-
-			$wpdb->query($sql);
+			wp_update_post( array( 'ID' => absint( $rows['ID'] ), 'post_content' => $post_content ) );
 		}
 		
 		// Trigger possible updates on CDN and other plugins 

--- a/upload.php
+++ b/upload.php
@@ -182,5 +182,4 @@ if (is_uploaded_file($_FILES["userfile"]["tmp_name"])) {
 }
 
 //save redirection
-wp_redirect($returnurl);
-?>	
+wp_safe_redirect( $returnurl );

--- a/upload.php
+++ b/upload.php
@@ -181,10 +181,6 @@ if (is_uploaded_file($_FILES["userfile"]["tmp_name"])) {
 	$returnurl = admin_url( '/wp-admin/upload.php' );
 }
 
-if (FORCE_SSL_ADMIN) {
-	$returnurl = str_replace("http:", "https:", $returnurl);
-}
-
 //save redirection
 wp_redirect($returnurl);
 ?>	


### PR DESCRIPTION
This is not yet complete, but I wanted to share progress to make sure that @mansj is on board with the approach. We should avoid using direct SQL statements as much as possible and use other methods available to us.

* Uses `get_post()` for single queries in `popup.php` and `upload.php`
* Uses `wp_update_post()` to update individual attachments
* Uses `get_post_meta()` and `update_post_meta()` to update meta information.
* Uses `admin_url()` rather than `get_bloginfo("wp_url")`, which allows us to drop `FORCE_SSL_ADMIN`
* Uses `wp_safe_redirect()` to ensure safe local redirects

I'm in progress on using `WP_Query()` to search for existing content.