### PR TITLE
Allow other plugins to control the $unfiltered passed to get_attached_file()

### DIFF
--- a/upload.php
+++ b/upload.php
@@ -67,7 +67,7 @@ list($current_filename, $current_filetype) = $wpdb->get_row($sql, ARRAY_N);
 $current_guid = $current_filename;
 $current_filename = substr($current_filename, (strrpos($current_filename, "/") + 1));
 
-$current_file = get_attached_file((int) $_POST["ID"], true);
+$current_file = get_attached_file((int) $_POST["ID"], apply_filters( 'emr_unfiltered_get_attached_file', true ));
 $current_path = substr($current_file, 0, (strrpos($current_file, "/")));
 $current_file = str_replace("//", "/", $current_file);
 $current_filename = basename($current_file);


### PR DESCRIPTION
Some background: Our plugin https://wordpress.org/plugins/amazon-s3-and-cloudfront/ allows users to copy files to S3 and gives the option to remove the local files from the server. This becomes problematic for other plugins that use `get_attached_file()`, as it no longer exists. However, we hook into `get_attached_file()` when necessary to copy back the file to the server so certain plugins use it.

At the moment your plugin tells `get_attached_file()`  to NOT filter the result by passing `true` to the `$unfiltered` parameter, therefore we can't grab it from S3 and the replace process breaks down. We have a number of users using both plugins so it would be great to get this in :)