### PR TITLE
Fix: Better error handling for get modified date

### DIFF
--- a/enable-media-replace.php
+++ b/enable-media-replace.php
@@ -127,11 +127,17 @@ function emr_get_modified_date($atts) {
     // Get path to file
 	$current_file = get_attached_file($id);
 
+	if ( ! file_exists( $current_file ) ) {
+		return $content;
+	}
+
 	// Get file modification time
 	$filetime = filemtime($current_file);
 
-	// do date conversion
-	$content = date($format, $filetime);
+	if ( false !== $filetime ) {
+		// do date conversion
+		$content = date( $format, $filetime );
+	}
 	
 	return $content;
 

--- a/enable-media-replace.php
+++ b/enable-media-replace.php
@@ -128,7 +128,7 @@ function emr_get_modified_date($atts) {
 	$current_file = get_attached_file($id);
 
 	if ( ! file_exists( $current_file ) ) {
-		return $content;
+		return false;
 	}
 
 	// Get file modification time
@@ -136,11 +136,10 @@ function emr_get_modified_date($atts) {
 
 	if ( false !== $filetime ) {
 		// do date conversion
-		$content = date( $format, $filetime );
+		return date( $format, $filetime );
 	}
 	
-	return $content;
-
+	return false;
 }
 
 // Add Last replaced by EMR plugin in the media edit screen metabox - Thanks Jonas Lundman (http://wordpress.org/support/topic/add-filter-hook-suggestion-to)
@@ -149,9 +148,14 @@ function ua_admin_date_replaced_media_on_edit_media_screen() {
 	global $post;
 	$id = $post->ID;
 	$shortcode = "[file_modified id=$id]";
+
+	$file_modified_time = do_shortcode($shortcode);
+	if ( ! $file_modified_time ) {
+		return;
+	}
 	?>
 	<div class="misc-pub-section curtime">
-		<span id="timestamp"><?php _e( 'Revised', 'enable-media-replace' ); ?>: <b><?php echo do_shortcode($shortcode); ?></b></span>
+		<span id="timestamp"><?php _e( 'Revised', 'enable-media-replace' ); ?>: <b><?php echo $file_modified_time; ?></b></span>
 	</div>
 	<?php
 }


### PR DESCRIPTION
[WP Offload S3](https://wordpress.org/plugins/amazon-s3-and-cloudfront/) allows users to upload attachments to S3 and remove them locally. When this happens, a PHP warning is thrown for `filemtime()`