### PR TITLE
Make $returnurl filterable, use admin_url

### DIFF
--- a/upload.php
+++ b/upload.php
@@ -184,7 +184,7 @@ if (is_uploaded_file($_FILES["userfile"]["tmp_name"])) {
 
 	}
 
-	$returnurl = get_bloginfo("wpurl") . "/wp-admin/post.php?post={$_POST["ID"]}&action=edit&message=1";
+	$returnurl = admin_url("/post.php?post={$_POST["ID"]}&action=edit&message=1");
 	
 	// Execute hook actions - thanks rubious for the suggestion!
 	if (isset($new_guid)) { do_action("enable-media-replace-upload-done", ($new_guid ? $new_guid : $current_guid)); }
@@ -192,12 +192,15 @@ if (is_uploaded_file($_FILES["userfile"]["tmp_name"])) {
 } else {
 	//TODO Better error handling when no file is selected.
 	//For now just go back to media management
-	$returnurl = get_bloginfo("wpurl") . "/wp-admin/upload.php";
+	$returnurl = admin_url("/wp-admin/upload.php");
 }
 
 if (FORCE_SSL_ADMIN) {
 	$returnurl = str_replace("http:", "https:", $returnurl);
 }
+
+// Allow developers to override $returnurl
+$returnurl = apply_filters('emr_returnurl', $returnurl);
 
 //save redirection
 wp_redirect($returnurl);


### PR DESCRIPTION
I have a need to direct a user to the media upload page ("wp-admin/upload.php?item=POST_ID") instead of the post edit page for the media item. This is because of a role plugin that (intentionally) blocks access to the posts edit page. I've added a filter right before the redirection call (though it could possibly go above `if (FORCE_SSL_ADMIN) {`). 

To use, in `functions.php`:

```php
function change_enable_media_replace_returnurl( $returnurl ) {
	return admin_url( "upload.php?item=" . (int) $_POST["ID"] );
}
add_filter( 'emr_returnurl', 'change_enable_media_replace_returnurl' );
```