### PR TITLE
Allow the unique filename to be filterable

### DIFF
--- a/upload.php
+++ b/upload.php
@@ -115,7 +115,8 @@ if (is_uploaded_file($_FILES["userfile"]["tmp_name"])) {
 		emr_delete_current_files($current_file);
 
 		// Massage new filename to adhere to WordPress standards
-		$new_filename= wp_unique_filename( $current_path, $new_filename );
+		$new_filename = wp_unique_filename( $current_path, $new_filename );
+		$new_filename = apply_filters( 'emr_unique_filename', $new_filename, $current_path, (int) $_POST['ID'] );
 
 		// Move new file to old location, new name
 		$new_file = $current_path . "/" . $new_filename;


### PR DESCRIPTION
Hi there!

This little PR solves a problem for us (@deliciousbrains) where the generated filename is not unique if the media files do not exist on the local server as is possible with WP Offload S3.  We perform similar checks in a few other cases with WordPress core and this would allow us to make sure the generated filename is unique on S3 as well.