### PR TITLE
Make the "upload done" hook more useful

### DIFF
--- a/upload.php
+++ b/upload.php
@@ -187,7 +187,7 @@ if (is_uploaded_file($_FILES["userfile"]["tmp_name"])) {
 	$returnurl = get_bloginfo("wpurl") . "/wp-admin/post.php?post={$_POST["ID"]}&action=edit&message=1";
 	
 	// Execute hook actions - thanks rubious for the suggestion!
-	if (isset($new_guid)) { do_action("enable-media-replace-upload-done", ($new_guid ? $new_guid : $current_guid)); }
+	if (isset($new_guid)) { do_action("enable-media-replace-upload-done", $new_guid, $current_guid); }
 	
 } else {
 	//TODO Better error handling when no file is selected.


### PR DESCRIPTION
As it is now, the "upload done" hook that fires after the replacement has occurred is not particularly useful as it only sends along the new guid. If, for instance, a user wants to hook in and perform a search/replace against additional tables, they don't have the original guid from which to work. 

This simply passes the current guid along with the new guid. It also removes the ternary operator that was checking for the new guid, as the hook is already wrapped in an `isset()` conditional that should handle that already. 